### PR TITLE
added new Task-based async implementations for API

### DIFF
--- a/GiphyApiClient.NetCore/Client/GiphyClient.cs
+++ b/GiphyApiClient.NetCore/Client/GiphyClient.cs
@@ -3,7 +3,7 @@ using RestSharp;
 using GiphyApiClient.NetCore.Models.Input;
 using GiphyApiClient.NetCore.Models.Output;
 using GiphyApiClient.NetCore.Config;
-using System.Net;
+using System.Threading.Tasks;
 
 namespace GiphyApiClient.NetCore.Client
 {
@@ -23,215 +23,42 @@ namespace GiphyApiClient.NetCore.Client
 
         public RestRequestAsyncHandle SearchAsync(SearchParams searchInput, Action<IRestResponse<MultipleResult>, RestRequestAsyncHandle> callback)
         {
-
-            var restRequest = new RestRequest(resource: "search",
-                method: Method.GET);
-            restRequest.AddParameter(new Parameter()
-            {
-                Name = "q",
-                Value = searchInput.q,
-                Type = ParameterType.QueryString
-            });
-
-
-            if (searchInput.limit.HasValue)
-            {
-                restRequest.AddParameter(new Parameter()
-                {
-                    Name = "limit",
-                    Value = searchInput.limit,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            if (searchInput.offset.HasValue)
-            {
-                restRequest.AddParameter(new Parameter()
-                {
-                    Name = "offset",
-                    Value = searchInput.offset,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            if (!string.IsNullOrEmpty(searchInput.rating))
-            {
-                restRequest.AddParameter(new Parameter()
-                {
-                    Name = "rating",
-                    Value = searchInput.rating,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            if (!string.IsNullOrEmpty(searchInput.lang))
-            {
-                restRequest.AddParameter(new Parameter()
-                {
-                    Name = "lang",
-                    Value = searchInput.lang,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-
-            if (!string.IsNullOrEmpty(searchInput.fmt))
-            {
-                restRequest.AddParameter(new Parameter()
-                {
-                    Name = "fmt",
-                    Value = searchInput.fmt,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            restRequest.AddParameter(new Parameter()
-            {
-                Name = "api_key",
-                Value = Config.ApiKey,
-                Type = ParameterType.QueryString
-            });
-            
+            var restRequest = new RequestBuilder()
+                .GetSearchRequest(searchInput)
+                .WithApiKey(Config.ApiKey)
+                .Build();
+       
             return RestClnt.GetAsync<MultipleResult>(restRequest, callback);            
         }
 
         public RestRequestAsyncHandle TrendingAsync(TrendingParams input, Action<IRestResponse<MultipleResult>, RestRequestAsyncHandle> callback)
         {
-        
-            var restRequest = new RestRequest(resource: "trending",
-                method: Method.GET);
-            if (input.limit.HasValue)
-            {
-                restRequest.AddParameter(new Parameter() 
-                {
-                    Name = "limit",
-                    Value = input.limit.Value,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            if (!string.IsNullOrEmpty(input.rating))
-            {
-                restRequest.AddParameter(new Parameter()
-                {
-                    Name = "rating",
-                    Value = input.rating,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            if (!string.IsNullOrEmpty(input.fmt))
-            {
-                restRequest.AddParameter(new Parameter()
-                {
-                    Name = "fmt",
-                    Value = input.fmt,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            restRequest.AddParameter(new Parameter()
-            {
-                Name = "api_key",
-                Value = Config.ApiKey,
-                Type = ParameterType.QueryString
-            });
+            var restRequest = new RequestBuilder()
+                .GetTrendingRequest(input)
+                .WithApiKey(Config.ApiKey)
+                .Build();           
 
            return RestClnt.GetAsync<MultipleResult>(restRequest, callback);
         }
 
         public RestRequestAsyncHandle TranslateAsync(TranslateParams parms, Action<IRestResponse<SingleResult>, RestRequestAsyncHandle> callback)
         {
-            var request = new RestRequest(resource: "translate", method: Method.GET);
-            
-            request.AddParameter(new Parameter()
-            {
-                Name = "s",
-                Value = parms.s,
-                Type = ParameterType.QueryString
-            });
+            var request = new RequestBuilder()
+                .GetTranslateRequest(parms)
+                .WithApiKey(Config.ApiKey)
+                .Build();
 
-            if (!string.IsNullOrWhiteSpace(parms.rating))
-            {
-                request.AddParameter(new Parameter()
-                {
-                    Name = "rating",
-                    Value = parms.rating,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            if (!string.IsNullOrWhiteSpace(parms.lang))
-            {
-                request.AddParameter(new Parameter()
-                {
-                    Name = "lang",
-                    Value = parms.lang,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            if (!string.IsNullOrWhiteSpace(parms.fmt))
-            {
-                request.AddParameter(new Parameter()
-                {
-                    Name = "fmt",
-                    Value = parms.fmt,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            request.AddParameter(new Parameter()
-            {
-                Name = "api_key",
-                Value = Config.ApiKey, 
-                Type = ParameterType.QueryString
-            });
-            
             return RestClnt.GetAsync<SingleResult>(request, callback);
         }
 
         public RestRequestAsyncHandle RandomAsync(RandomParams parms, Action<IRestResponse<RandomResult>, RestRequestAsyncHandle> callback)
         {
-            var request = new RestRequest(resource: "random");
-            if (!string.IsNullOrWhiteSpace(parms.tag))
-            {
-                request.AddParameter(new Parameter()
-                {
-                    Name = "tag",
-                    Value = parms.tag,
-                    Type = ParameterType.QueryString
-                });
-            }
+            var request = new RequestBuilder()
+                .GetRandomRequest(parms)
+                .WithApiKey(Config.ApiKey)
+                .Build();
 
-            if (!string.IsNullOrWhiteSpace(parms.rating))
-            {
-                request.AddParameter(new Parameter()
-                {
-                    Name = "rating",
-                    Value = parms.rating,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            if (!string.IsNullOrWhiteSpace(parms.fmt))
-            {
-                request.AddParameter(new Parameter()
-                {
-                    Name = "fmt",
-                    Value = parms.fmt,
-                    Type = ParameterType.QueryString
-                });
-            }
-
-            request.AddParameter(new Parameter()
-            {
-                Name = "api_key",
-                Value = Config.ApiKey,
-                Type = ParameterType.QueryString
-            });
-
-           return RestClnt.GetAsync<RandomResult>(request, callback);
+            return RestClnt.GetAsync<RandomResult>(request, callback);
         } 
 
         public RestRequestAsyncHandle GifByIdAsync(GifByIdParams parms, Action<IRestResponse<SingleResult>, RestRequestAsyncHandle> callback)
@@ -241,20 +68,20 @@ namespace GiphyApiClient.NetCore.Client
                 throw new ArgumentException("id parameter is not optional");
             }
 
-            var request = new RestRequest(resource: parms.id);
-            request.AddParameter(new Parameter()
-            {
-                Name = "api_key", 
-                Value = Config.ApiKey,
-                Type = ParameterType.QueryString
-            });
+            var request = new RequestBuilder()
+                .GetSearchByIdRequest(parms)
+                .WithApiKey(Config.ApiKey)
+                .Build();
 
             return RestClnt.GetAsync(request, callback);
         }
 
+        ///<remarks>
+        ///There are some problems with this implementation, specifically that it has to new up a special client to get this done.
+        /// The reason is that the <code>ids</code> parameter is a csv format, which RestSharp doesn't seem to like.
+        ///</remarks>
         public RestRequestAsyncHandle GifsByIdAsync(GifsByIdParams parms, Action<IRestResponse<MultipleResult>, RestRequestAsyncHandle> callback)
         {
-
             if (string.IsNullOrWhiteSpace(parms.ids))
             {
                 throw new ArgumentException("ids parameter is not optional");
@@ -262,6 +89,67 @@ namespace GiphyApiClient.NetCore.Client
             var specialClient = new RestClient($"{Config.BaseUrl}?api_key={Config.ApiKey}&ids={parms.ids}");
             var request = new RestRequest();
             return specialClient.GetAsync<MultipleResult>(request, callback);
+        }
+
+        public Task<IRestResponse<MultipleResult>> SearchAsyncTask(SearchParams parms)
+        {
+            var request = new RequestBuilder()
+                .GetSearchRequest(parms)
+                .WithApiKey(Config.ApiKey)
+                .Build();
+            
+            return RestClnt.ExecuteGetTaskAsync<MultipleResult>(request);
+        }
+
+        public Task<IRestResponse<MultipleResult>> TrendingAsyncTask(TrendingParams parms)
+        {
+            var request = new RequestBuilder()
+                .GetTrendingRequest(parms)
+                .WithApiKey(Config.ApiKey)
+                .Build();
+            
+            return RestClnt.ExecuteGetTaskAsync<MultipleResult>(request);
+        }
+
+        public Task<IRestResponse<SingleResult>> TranslateAsyncTask(TranslateParams parms)
+        {
+            var request = new RequestBuilder()
+                .GetTranslateRequest(parms)
+                .WithApiKey(Config.ApiKey)
+                .Build();
+            
+            return RestClnt.ExecuteGetTaskAsync<SingleResult>(request);
+        }
+
+        public Task<IRestResponse<RandomResult>> RandomAsyncTask(RandomParams parms)
+        {
+            var request = new RequestBuilder()
+                .GetRandomRequest(parms)
+                .WithApiKey(Config.ApiKey)
+                .Build();
+
+            return RestClnt.ExecuteGetTaskAsync<RandomResult>(request);
+        }
+
+        public Task<IRestResponse<SingleResult>> GifByIdAsyncTask(GifByIdParams parms)
+        {
+            var request = new RequestBuilder()
+                .GetSearchByIdRequest(parms)
+                .WithApiKey(Config.ApiKey)
+                .Build();
+            
+            return RestClnt.ExecuteGetTaskAsync<SingleResult>(request);
+        }
+
+        public Task<IRestResponse<MultipleResult>> GifsByIdsAsyncTask(GifsByIdParams parms)
+        {
+            if (string.IsNullOrWhiteSpace(parms.ids))
+            {
+                throw new ArgumentException("ids parameter is not optional");
+            }
+            var specialClient = new RestClient($"{Config.BaseUrl}?api_key={Config.ApiKey}&ids={parms.ids}");
+            var request = new RestRequest();
+            return specialClient.ExecuteGetTaskAsync<MultipleResult>(request);
         }
     }
 }

--- a/GiphyApiClient.NetCore/Client/IGiphyClient.cs
+++ b/GiphyApiClient.NetCore/Client/IGiphyClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using GiphyApiClient.NetCore.Models.Input;
 using GiphyApiClient.NetCore.Models.Output;
 using RestSharp;
@@ -8,7 +9,7 @@ namespace GiphyApiClient.NetCore.Client
     ///<remarks>
     ///Implements the set of API operations noted in Giphy's public-facing client; documented at https://github.com/Giphy/GiphyApi
     ///Does NOT implement the "sticker" api yet.
-    ///NOTE: all of the operations here are asynchronous. 
+    ///NOTE: all of the operations here are asynchronous, but they come in two flavors - One returns RestSharp's RestRequestAsyncHandle, and the second set returns a Task that can be <code>await</code>ed.   
     ///</remarks>
     public interface IGiphyClient
     {
@@ -18,5 +19,12 @@ namespace GiphyApiClient.NetCore.Client
         RestRequestAsyncHandle RandomAsync(RandomParams input, Action<IRestResponse<RandomResult>, RestRequestAsyncHandle> callback);
         RestRequestAsyncHandle GifByIdAsync(GifByIdParams parms, Action<IRestResponse<SingleResult>, RestRequestAsyncHandle> callback);
         RestRequestAsyncHandle GifsByIdAsync(GifsByIdParams parms, Action<IRestResponse<MultipleResult>, RestRequestAsyncHandle> callback);
+        Task<IRestResponse<MultipleResult>> SearchAsyncTask(SearchParams searchParams);
+        Task<IRestResponse<MultipleResult>> TrendingAsyncTask(TrendingParams trendingParams);
+        Task<IRestResponse<SingleResult>> TranslateAsyncTask(TranslateParams translateParams);
+        Task<IRestResponse<RandomResult>> RandomAsyncTask(RandomParams randomParams);
+        Task<IRestResponse<SingleResult>> GifByIdAsyncTask(GifByIdParams idParams);
+        Task<IRestResponse<MultipleResult>> GifsByIdsAsyncTask(GifsByIdParams idsParams);
+
     }
 }

--- a/GiphyApiClient.NetCore/Client/RequestBuilder.cs
+++ b/GiphyApiClient.NetCore/Client/RequestBuilder.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using RestSharp;
+
+namespace GiphyApiClient.NetCore.Client
+{
+    internal class RequestBuilder
+    {
+        private string Resource;
+        private Method RequestMethod;
+        private readonly List<Parameter> ParameterList;
+
+        public RequestBuilder()
+        {
+            ParameterList = new List<Parameter>();
+        }
+
+        public RequestBuilder ForResource(string resource)
+        {
+            Resource = resource;
+            return this;
+        }
+
+        public RequestBuilder WithMethod(Method method)
+        {
+            RequestMethod = method;
+            return this;
+        }
+
+        public RequestBuilder AddParameter(string name, object val, ParameterType type)
+        {
+            ParameterList.Add(new Parameter() 
+            {
+                Name = name,
+                Value = val,
+                Type = type
+            });
+
+            return this;
+        }
+
+        public IRestRequest Build()
+        {            
+            if (Resource == null)
+            {
+                throw new InvalidOperationException("you must assign a resource. If calling the root of your API, just pass String.Empty to the ForResource() method.");
+            }
+
+            //This is assigning itself the same value. The only reason I'm doing this is to future-proof this in case the enum changes, which I doubt will happen but whatever...
+            if (RequestMethod == default(Method))
+            {
+                RequestMethod = Method.GET;
+            }
+
+            var request = new RestRequest(Resource, RequestMethod);
+            request.Parameters.AddRange(ParameterList);
+
+            return request;
+        }
+    }
+}

--- a/GiphyApiClient.NetCore/Client/RequestBuilderExtend.cs
+++ b/GiphyApiClient.NetCore/Client/RequestBuilderExtend.cs
@@ -1,0 +1,147 @@
+using GiphyApiClient.NetCore.Models.Input;
+using RestSharp;
+
+namespace GiphyApiClient.NetCore.Client
+{
+    ///<summary>
+    /// Convenience methods to make the requestBuilder build specific requests for this client.
+    ///</summary>
+    internal static class RequestBuilderExtend
+    {
+        //Resource names
+        private const string SEARCH = "search";
+        private const string TRENDING = "trending";
+        private const string TRANSLATE = "translate";
+        private const string RANDOM = "random";
+
+        //Param names
+        private const string Q = "q";
+        private const string LIMIT = "limit";
+        private const string OFFSET = "offset";
+        private const string RATING = "rating";
+        private const string LANG = "lang";
+        private const string FMT = "format";
+        private const string API_KEY = "api_key";
+        private const string S = "s";
+        private const string TAG = "tag";
+
+
+        public static RequestBuilder WithApiKey(this RequestBuilder builder, string apiKey)
+        {
+            return builder.AddParameter(API_KEY, apiKey, ParameterType.QueryString);
+        }
+
+        public static RequestBuilder GetSearchRequest(this RequestBuilder builder, SearchParams searchParams)
+        {
+            builder.ForResource(SEARCH)
+                .WithMethod(Method.GET)
+                .AddParameter(Q, searchParams.q, ParameterType.QueryString);
+
+            if (searchParams.limit.HasValue)
+            {
+                builder.AddParameter(LIMIT, searchParams.limit, ParameterType.QueryString);
+            }
+
+            if (searchParams.offset.HasValue)
+            {
+                builder.AddParameter(OFFSET, searchParams.offset, ParameterType.QueryString);
+            }
+
+            if (!string.IsNullOrEmpty(searchParams.rating))
+            {
+                builder.AddParameter(RATING, searchParams.rating, ParameterType.QueryString);
+            }
+
+            if (!string.IsNullOrEmpty(searchParams.lang))
+            {
+                builder.AddParameter(LANG, searchParams.lang, ParameterType.QueryString);
+            }
+
+            if (!string.IsNullOrEmpty(searchParams.fmt))
+            {
+                builder.AddParameter(FMT, searchParams.fmt, ParameterType.QueryString);
+            }
+
+            return builder;
+        }
+
+        public static RequestBuilder GetTrendingRequest(this RequestBuilder builder, TrendingParams trendingParams)
+        {
+            builder.ForResource(TRENDING)
+                .WithMethod(Method.GET);
+
+            if (trendingParams.limit.HasValue)
+            {
+                builder.AddParameter(LIMIT, trendingParams.limit.Value, ParameterType.QueryString);
+            }
+
+            if (!string.IsNullOrEmpty(trendingParams.rating))
+            {
+                builder.AddParameter(RATING, trendingParams.rating, ParameterType.QueryString);
+            }
+
+            if (!string.IsNullOrEmpty(trendingParams.fmt))
+            {
+                builder.AddParameter(FMT, trendingParams.fmt, ParameterType.QueryString);
+            }
+
+            return builder;
+        }
+
+        public static RequestBuilder GetTranslateRequest(this RequestBuilder builder, TranslateParams parms)
+        {
+            builder.ForResource(TRANSLATE)
+                .WithMethod(Method.GET)
+                .AddParameter(S, parms.s, ParameterType.QueryString);
+
+            if (!string.IsNullOrWhiteSpace(parms.rating))
+            {
+                builder.AddParameter(RATING, parms.rating, ParameterType.QueryString);
+            }
+
+            if (!string.IsNullOrWhiteSpace(parms.lang))
+            {
+                builder.AddParameter(LANG, parms.lang, ParameterType.QueryString);
+            }
+
+            if (!string.IsNullOrWhiteSpace(parms.fmt))
+            {
+                builder.AddParameter(FMT, parms.fmt, ParameterType.QueryString);
+            }
+
+            return builder;
+        }
+
+        public static RequestBuilder GetRandomRequest(this RequestBuilder builder, RandomParams parms)
+        {
+            builder.ForResource(RANDOM)
+                .WithMethod(Method.GET);
+            
+            if (!string.IsNullOrWhiteSpace(parms.tag))
+            {
+                builder.AddParameter(TAG, parms.tag, ParameterType.QueryString);
+            }
+
+            if (!string.IsNullOrWhiteSpace(parms.rating))
+            {
+                builder.AddParameter(RATING, parms.rating, ParameterType.QueryString);
+            }
+
+            if (!string.IsNullOrWhiteSpace(parms.fmt))
+            {
+                builder.AddParameter(FMT, parms.fmt, ParameterType.QueryString);
+            }
+
+            return builder;
+        }
+
+        public static RequestBuilder GetSearchByIdRequest(this RequestBuilder builder, GifByIdParams parms)
+        {
+            builder.ForResource(parms.id)
+                .WithMethod(Method.GET);
+            return builder;
+        }        
+
+
+    }
+}

--- a/GiphyApiClient.NetCore/Client/RestClientExtend.cs
+++ b/GiphyApiClient.NetCore/Client/RestClientExtend.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using RestSharp;
+
+namespace GiphyApiClient.NetCore.Client
+{
+
+    ///<summary>
+    ///This set of extension methods is meant to provide a stopgap, RestSharp has methods that do implement the async/await pattern, but the .net core lib i'm using does not. 
+    ///therefore, I grabbed some of the async task methods defined here: https://github.com/restsharp/RestSharp/blob/e7c65df751427298cb59f5456bbf1f59967996be/RestSharp/RestClient.Async.cs
+    ///</summary>
+    ///<remarks>
+    /// Am tracking development of ZhongZf's fork of RestSharp with .net core support.  
+    /// When these methods are implemented there, this class can go away. 
+    /// If i understand correctly, it should be just a change to a specific compiler directive noted in the class above.
+    /// see https://github.com/zhongzf/RestSharp    
+    ///</remarks>
+    public static class RestClientExtend
+    {
+        public static Task<IRestResponse<T>> ExecuteTaskAsync<T>(this IRestClient client, IRestRequest request, CancellationToken token)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
+            TaskCompletionSource<IRestResponse<T>> taskCompletionSource = new TaskCompletionSource<IRestResponse<T>>();
+
+            try
+            {
+                RestRequestAsyncHandle async = client.ExecuteAsync<T>(
+                    request,
+                    (response, _) =>
+                    {
+                        if (token.IsCancellationRequested)
+                        {
+                            taskCompletionSource.TrySetCanceled();
+                        }
+                        // Don't run TrySetException, since we should set Error properties and swallow exceptions
+                        // to be consistent with sync methods
+                        else
+                        {
+                            taskCompletionSource.TrySetResult(response);
+                        }
+                    });
+
+
+                CancellationTokenRegistration registration =
+                    token.Register(() =>
+                                   {
+                                       async.Abort();
+                                       taskCompletionSource.TrySetCanceled();
+                                   });
+
+
+                taskCompletionSource.Task.ContinueWith(t => registration.Dispose(), token);
+            }
+            catch (Exception ex)
+            {
+                taskCompletionSource.TrySetException(ex);
+            }
+
+            return taskCompletionSource.Task;
+        }
+             
+        public static Task<IRestResponse<T>> ExecuteGetTaskAsync<T>(this IRestClient client, IRestRequest request)
+        {
+            return client.ExecuteGetTaskAsync<T>(request, CancellationToken.None);
+        }
+
+        public static Task<IRestResponse<T>> ExecuteGetTaskAsync<T>(this IRestClient client, IRestRequest request, CancellationToken token)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
+            request.Method = Method.GET;
+            return client.ExecuteTaskAsync<T>(request, token);
+        }
+
+        public static Task<IRestResponse<T>> ExecutePostTaskAsync<T>(this IRestClient client, IRestRequest request, CancellationToken token)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
+            request.Method = Method.POST;
+
+            return client.ExecuteTaskAsync<T>(request, token);
+        }
+
+        public static Task<IRestResponse<T>> ExecutePostTaskAsync<T>(this IRestClient client, IRestRequest request)
+        {
+            return client.ExecutePostTaskAsync<T>(request, CancellationToken.None);
+        }
+
+        public static Task<IRestResponse<T>> ExecuteTaskAsync<T>(this IRestClient client, IRestRequest request)
+        {
+            return client.ExecuteTaskAsync<T>(request, CancellationToken.None);
+        }
+
+        public static Task<IRestResponse> ExecuteTaskAsync(this IRestClient client, IRestRequest request)
+        {
+            return client.ExecuteTaskAsync(request, CancellationToken.None);
+        }
+
+        public static Task<IRestResponse> ExecuteGetTaskAsync(this IRestClient client, IRestRequest request)
+        {
+            return client.ExecuteGetTaskAsync(request, CancellationToken.None);
+        }
+
+        public static Task<IRestResponse> ExecuteGetTaskAsync(this IRestClient client, IRestRequest request, CancellationToken token)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
+            request.Method = Method.GET;
+            return client.ExecuteTaskAsync(request, token);
+        }
+
+        public static Task<IRestResponse> ExecutePostTaskAsync(this IRestClient client, IRestRequest request)
+        {
+            return client.ExecutePostTaskAsync(request, CancellationToken.None);
+        }
+
+        public static Task<IRestResponse> ExecutePostTaskAsync(this IRestClient client, IRestRequest request, CancellationToken token)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
+            request.Method = Method.POST;
+            return client.ExecuteTaskAsync(request, token);
+        }
+
+        public static Task<IRestResponse> ExecuteTaskAsync(this IRestClient client, IRestRequest request, CancellationToken token)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
+            TaskCompletionSource<IRestResponse> taskCompletionSource = new TaskCompletionSource<IRestResponse>();
+
+            try
+            {
+                RestRequestAsyncHandle async = client.ExecuteAsync(
+                    request,
+                    (response, _) =>
+                    {
+                        if (token.IsCancellationRequested)
+                        {
+                            taskCompletionSource.TrySetCanceled();
+                        }
+                        // Don't run TrySetException, since we should set Error
+                        // properties and swallow exceptions to be consistent
+                        // with sync methods
+                        else
+                        {
+                            taskCompletionSource.TrySetResult(response);
+                        }
+                    });
+
+                CancellationTokenRegistration registration =
+                    token.Register(() =>
+                                   {
+                                       async.Abort();
+                                       taskCompletionSource.TrySetCanceled();
+                                   });
+
+
+                taskCompletionSource.Task.ContinueWith(t => registration.Dispose(), token);
+            }
+            catch (Exception ex)
+            {
+                taskCompletionSource.TrySetException(ex);
+            }
+
+            return taskCompletionSource.Task;
+        }
+    }
+    
+}

--- a/GiphyApiClient.NetCore/project.json
+++ b/GiphyApiClient.NetCore/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.1.0",
 
   "dependencies": {
     "NETStandard.Library": "1.6.0",

--- a/GiphyApiClientTestDrive/project.json
+++ b/GiphyApiClientTestDrive/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.0.1",
   "buildOptions": {
     "emitEntryPoint": true
   },
@@ -9,7 +9,7 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "GiphyApiClient.NetCore" : "1.0.0", 
+    "GiphyApiClient.NetCore" : "1.1.0", 
     "System.Runtime.Serialization.Formatters": "4.0.0-rc3-24212-01",
     "RestSharp.NetCore": "105.2.3"
   },


### PR DESCRIPTION
Also, fixed some cruft that existed in 1.0.0:
the client used a bunch of magic strings to construct parameters before.
Now we put that stuff in a RequestBuilder with some extension methods
to give us what we need.

updated version to 1.1.0 because we added new interface methods.